### PR TITLE
Run db:seed instead of db:setup in postdeploy heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,6 @@
   "description": "This client is based on the Rapidfire gem and you can use this to conduct surveys for your projects",
   "repository": "https://github.com/code-mancers/rapidfire-demo",
   "scripts": {
-    "postdeploy": "bin/rails db:setup"
+    "postdeploy": "bin/rails db:seed"
   }
 }


### PR DESCRIPTION
According to heroku docs the postdeploy runs after the release phase, in
relase phase the rake db:migrate would have already run, so db:setup is
not required here in postdeploy.