### PR TITLE
Remove unnecessary classes from checkbox & radiobutton quesions

### DIFF
--- a/app/views/rapidfire/answers/_checkbox.html.erb
+++ b/app/views/rapidfire/answers/_checkbox.html.erb
@@ -5,7 +5,7 @@
 <br>
 <%= f.fields_for :answer_text do |af| %>
   <%- answer.question.options.each_with_index do |option, index| %>
-    <%= af.label index, class: "checkbox subtitle is-6 full-width height-fit-content" do %>
+    <%= af.label index, class: "checkbox full-width" do %>
       <%= af.check_box index, { checked: checkbox_checked?(answer, option) }, option %>
       <%= option %>
     <% end %>

--- a/app/views/rapidfire/answers/_radio.html.erb
+++ b/app/views/rapidfire/answers/_radio.html.erb
@@ -5,7 +5,7 @@
   <br>
   <%- answer.question.options.each_with_index do |option, index| %>
     <span class="form-group sub">
-      <%= f.label "answer_text_#{index}", class: "radio subtitle is-6" do %>
+      <%= f.label "answer_text_#{index}", class: "radio" do %>
         <%= f.radio_button :answer_text, option, id: "#{f.object_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").sub(/_$/, "")}_answer_text_#{index}" %>
         <%= option %>
       <% end %>


### PR DESCRIPTION
The subtitle class with 'is-6' class works well on chrome but breaks on
mobile view and firefox, so removing as it is not adding much style to
the view anyway.