### PR TITLE
fix(dockerfile):match bundler version in the dockerfile to Gemfile.lock's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache build-base bash nodejs postgresql-dev yarn tzdata
 
 WORKDIR /app
 
-RUN gem install bundler
+RUN gem install bundler:2.0.2
 
 COPY Gemfile ./
 COPY Gemfile.lock ./
@@ -12,7 +12,7 @@ RUN bundle install
 
 COPY package.json ./
 COPY yarn.lock ./
-RUN yarn install
+RUN yarn install --network-timeout=30000
 
 ENV BUNDLE_GEMFILE=./Gemfile
 ENV PATH=/app/bin:$PATH


### PR DESCRIPTION


Also add a flag to increase network timeout for yarn install, as it's
failing otherwise with network error but the network is just fine.